### PR TITLE
Form reset at successful form submission

### DIFF
--- a/addspecimen.sql
+++ b/addspecimen.sql
@@ -39,10 +39,6 @@ ALTER TABLE biospecimen ADD CONSTRAINT fk_biospecimen_biospecimen_type_1 FOREIGN
 -- ALTER TABLE biospecimen ADD CONSTRAINT fk_biospcimen_biobanking_ra_id_1 FOREIGN KEY (`collection_ra_id`) REFERENCES `biobanking_ra` (`id`);
 ALTER TABLE biospecimen ADD CONSTRAINT fk_biospecimen_freezer_id_1 FOREIGN KEY (`freezer_id`) REFERENCES `freezer` (`id`);
 
-
-
-
-
 DROP TABLE `biospecimen_type`;
 CREATE TABLE `biospecimen_type` (
   `id` int(3) NOT NULL AUTO_INCREMENT,

--- a/js/biobanking_helper.js
+++ b/js/biobanking_helper.js
@@ -1,8 +1,15 @@
 $(document).ready(function() {
 
-
-
         var candInfo= JSON.parse(document.getElementsByName('data')[0].value);
+
+        //reset zepsom id to that of prior submission
+        document.getElementsByName('zepsom_id')[0].value = JSON.parse(sessionStorage.getItem("zid"));
+        sessionStorage.removeItem("zid");
+
+        //reset form if submission is successful
+        if (document.getElementById('success')) {
+            resetForm();
+        };
 
         $(".biospecimen-link").click(function(e){
             loris.loadFilteredMenuClickHandler(
@@ -44,10 +51,9 @@ $(document).ready(function() {
             });
         });
 
-        //if form submission is invalid zepsomAutoPopulate() and biospecimenAutoPopulate() run again
+        //zepsomAutoPopulate() and biospecimenAutoPopulate() run on every page load
         zepsomAutoPopulate();
         biospecimenAutoPopulate();
-
 
         //passes to next biospecimen field once input is given
         var biospecimenIdFields = $("input[name^='biospecimen_id']");
@@ -55,17 +61,14 @@ $(document).ready(function() {
             // define variables
             let current = $(':focus').attr('name');
             console.log(current);
-            for (i=0; i < 3;i ++) {
+            for (i=0; i<(biospecimenIdFields.length - 1); i++) {
                 if ($(biospecimenIdFields[i]).attr('name') == current)
                 {
                     var nextField = $(biospecimenIdFields[i+1]);
                 }
-
             }
-            // check if its a delete or a backspace. erase time if field is erased
+            // check if its a delete (46) or a backspace (8). erase time if field is erased
             // Do not go to next line
-            // DELETE -> 46
-            // BACKSPACE -> 8
             if (e.keyCode == 8 || e.keyCode == 46) {
             } else {
                 // wait .5 sec after a keyup event in the barcode field
@@ -73,12 +76,37 @@ $(document).ready(function() {
                     if (nextField.val() === "") {
                         nextField.focus();
                     }
-
                 }, 500);
             }
+
         });
+
     }
 );
+
+
+//refreshes the entire page after submission
+function storeZID() {
+
+    var zid = document.getElementsByName('zepsom_id')[0].value;
+    sessionStorage.setItem("zid", JSON.stringify(zid));
+}
+
+function resetForm() {
+    setTimeout(function(){location.href=loris.BaseURL+'/biobanking/?submenu=addBiospecimen&reset=true'}, 3000);
+    // setTimeout(function(){window.location.reload();},1000);
+}
+
+//set ZepsomID based on prior submission
+// function setZepsomID(zid) {
+//     document.getElementsByName('zepsom_id')[0].value = zid;
+// }
+
+
+//sets focus to first biospecimen field
+function focusBiospecimen() {
+    document.getElementsByName('biospecimen_id_iswab')[0].focus();
+}
 
 
 //ENABLES OR DISABLES FORM COLUMN DEPENDING ON VALIDITY PARAMETER. SPECIMEN TYPE MUST BE PASSED INTO FUNCTION.
@@ -155,9 +183,9 @@ function biospecimenAutoPopulate() {
 
     if(specimenInfo[zid]) {
         $.each(specimenInfo[zid], function (key, value) {
-
             if (specimenInfo[zid][key]['nb_samples_' + key] == '1') {
                 document.getElementsByName('nb_samples_' + key)[0].value = specimenInfo[zid][key]['nb_samples_' + key];
+                // document.getElementsByName('biospecimen_id_' + key)[0].value = specimenInfo[zid][key]['biospecimen_id_' + key];
                 $(document.getElementsByName('nb_samples_' + key)[0]).prop("disabled", true);
                 accessForm(key, true);
             }

--- a/php/NDB_Form_biobanking.class.inc
+++ b/php/NDB_Form_biobanking.class.inc
@@ -270,16 +270,13 @@ class NDB_Form_Biobanking extends NDB_Form
             $vals['specimen_type']=$type;
 
 
-            $success = $db->insert(
+            $db->insert(
                 'biospecimen',
                 $vals
             );
-//            $success = $db->insert(
-//                'biospecimen',
-//                $type
-//            );
-            $this->tpl_data['success'] = true;
         }
+
+        $this->tpl_data['success'] = true;
     }
 
 
@@ -355,6 +352,7 @@ class NDB_Form_Biobanking extends NDB_Form
         $biospecimenMapping = array();
         foreach ($biospecimenFields as $row) {
             $biospecimenMapping[$row['zepsom_id']][$row['specimen_type']]['nb_samples'.'_'.$row['specimen_type']] = $row['nb_samples'];
+            $biospecimenMapping[$row['zepsom_id']][$row['specimen_type']]['biospecimen_id'.'_'.$row['specimen_type']] = $row['biospecimen_id'];
         }
 
         $this->addHidden('data2', htmlspecialchars(json_encode($biospecimenMapping)));
@@ -406,7 +404,7 @@ class NDB_Form_Biobanking extends NDB_Form
             $externalId,
             array(
                 "required" => true,
-                "onchange" => "zepsomAutoPopulate(); consentRequired(); biospecimenAutoPopulate();",
+                "onchange" => "zepsomAutoPopulate(); consentRequired(); biospecimenAutoPopulate(); focusBiospecimen();",
             )
         );
 
@@ -443,21 +441,6 @@ class NDB_Form_Biobanking extends NDB_Form
 
             )
         );
-
-//        $this->addSelect(
-//            'participant_consent_biobank',
-//            'Biobank Consent',
-//            array(
-//                null  => '',
-//                'yes' => 'Yes',
-//                'no'  => 'No',
-//            ),
-//            array(
-//                'required' => true,
-//                'disabled' => ''
-//
-//            )
-//        );
 
         $this->addBasicText(
             'consent_date',
@@ -1002,6 +985,7 @@ class NDB_Form_Biobanking extends NDB_Form
     {
         $db =& Database::singleton();
         $errors = array();
+        $success = array();
 
         $query      = "SELECT ExternalID FROM candidate WHERE ExternalID IS NOT NULL ORDER By ExternalID";
         $rows       = $db->pselect($query, array());
@@ -1010,7 +994,7 @@ class NDB_Form_Biobanking extends NDB_Form
             $externalId[$row['ExternalID']] = $row['ExternalID'];
         }
 
-        $query      = "SELECT biospecimen_id, freezer_id, box_id, box_coordinates FROM biospecimen";
+        $query      = "SELECT zepsom_id, specimen_type, biospecimen_id, freezer_id, box_id, box_coordinates FROM biospecimen";
         $rows       = $db->pselect($query, array());
         $biospecimenId = array();
         foreach ($rows as $row) {
@@ -1081,16 +1065,16 @@ class NDB_Form_Biobanking extends NDB_Form
         //TODO fix $colInfo function -- currently not working
 //        foreach ($colInfo as $f => $t) {
 //            if ($t === 'date') {
-                foreach ($values as $k => $value) {
-                    if (strpos($k, 'collection_date') !== false) {
-                        // @todo Refactor this so there's no empty if block
-                        if ($values[$k] . trim() == '') {
-                            // Empty date: valid
-                        } elseif (DateTime::createFromFormat('d-M-Y', $values[$k]) === false) {
-                            $errors[$k] = "Not a valid date. You must enter a date of the form 01-Jan-2001\n";
-                        }
-                    }
+        foreach ($values as $k => $value) {
+            if (strpos($k, 'collection_date') !== false) {
+                // @todo Refactor this so there's no empty if block
+                if ($values[$k] . trim() == '') {
+                    // Empty date: valid
+                } elseif (DateTime::createFromFormat('d-M-Y', $values[$k]) === false) {
+                    $errors[$k] = "Not a valid date. You must enter a date of the form 01-Jan-2001\n";
                 }
+            }
+        }
 //            }
 //        }
 
@@ -1126,7 +1110,6 @@ class NDB_Form_Biobanking extends NDB_Form
                 $coordinateData[$type]['box_coordinates'] = $values['box_coordinates_' . $type];
             }
         }
-        print_r($coordinateData);
 
         foreach ($coordinateData as $type0 => $data0) {
             foreach ($coordinateData as $type1 => $data1) {
@@ -1147,6 +1130,7 @@ class NDB_Form_Biobanking extends NDB_Form
         }
 
         return $errors;
+
     }
 
     /**

--- a/templates/form_addBiospecimen.tpl
+++ b/templates/form_addBiospecimen.tpl
@@ -3,16 +3,20 @@
 {*BACKEND ERROR ALERT*}
 <form method="post" name="edit_biospecimen">
     {if $form.errors}
-    <div class="alert alert-danger" role="alert">
-        The form you submitted contains data entry errors:
-   	    {foreach from=$form.errors item=error key=k}
-   	        {if $k eq 'collection_date'}
-	        <br>&nbsp;<b>Collection Date</b>: {$error}
-	        {else}
-	        <br>&nbsp;<b>{$k}</b>: {$error}
-	        {/if}
-        {/foreach}
-    </div>
+        <div class="alert alert-danger" role="alert">
+            The form you submitted contains data entry errors:
+            {foreach from=$form.errors item=error key=k}
+                {if $k eq 'collection_date'}
+                    <br>&nbsp;<b>Collection Date</b>: {$error}
+                {else}
+                    <br>&nbsp;<b>{$k}</b>: {$error}
+                {/if}
+            {/foreach}
+        </div>
+    {elseif $success}
+        <div id="success" class="alert alert-success" role="alert" onload="resetForm()">
+            The biospecimen submission was successful.
+        </div>
     {/if}
 
     {*FORM HEADER*}
@@ -55,8 +59,8 @@
 
             {*Participant Consent*}
             {*<div class="col-xs-2">*}
-                {*<td>{$form.participant_consent_biobank.label}</td>*}
-                {*<td>{$form.participant_consent_biobank.html}</td>*}
+            {*<td>{$form.participant_consent_biobank.label}</td>*}
+            {*<td>{$form.participant_consent_biobank.html}</td>*}
             {*</div>*}
 
             {*Consent Date*}
@@ -224,10 +228,10 @@
             {*SAVE, RESET and BACK BUTTONS*}
             <div class="row form-group form-inline">
                 <div class="col-sm-2">
-                    <input id="save" class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit"/>
+                    <input id="save" class="btn btn-sm btn-primary col-xs-12" name="fire_away" value="Save" type="submit" onclick="storeZID()"/>
                 </div>
                 <div class="col-sm-2">
-                    <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset" />
+                    <input class="btn btn-sm btn-primary col-xs-12" value="Reset" type="reset"/>
                 </div>
                 <div class="col-sm-2">
                     <input class="btn btn-sm btn-primary col-xs-12" onclick="location.href='{$baseurl}/biobanking/?submenu=biospecimen_collection&biospecimen_id={$biospecimenId}'" value="Back" type="button" />


### PR DESCRIPTION
I made the form reset once there is a successful form submission. Also, the Zepsom ID is carried over to the new page and disables fields that already have data associated with them.