### PR TITLE
Fix location clash error message

### DIFF
--- a/php/NDB_Form_biobanking.class.inc
+++ b/php/NDB_Form_biobanking.class.inc
@@ -1390,8 +1390,8 @@ class NDB_Form_Biobanking extends NDB_Form
                 unset($location['zepsom_id']);
                 unset($location['specimen_type']);
                 if ($data0===$location) {
-                    $errors[$type0] = "Location '".$freezerNames[$values['freezer_id_'.$type]]." / ".
-                        $values['box_id_'.$type]." / ".$values['box_coordinates_'.$type].
+                    $errors[$type0] = "Location '".$freezerNames[$values['freezer_id_'.$type0]]." / ".
+                        $values['box_id_'.$type0]." / ".$values['box_coordinates_'.$type0].
                         "' is already occupied by another specimen.";
                 }
             }


### PR DESCRIPTION
Message displayed on the add specimen page when the user enters a location that's already taken by another specimen is incorrect. Fixed this.
