### PR TITLE
Unset bidInfo 

### DIFF
--- a/php/NDB_Form_biobanking.class.inc
+++ b/php/NDB_Form_biobanking.class.inc
@@ -401,8 +401,6 @@ class NDB_Form_Biobanking extends NDB_Form
             };
         }
 
-        print_r($values);
-
         if ($this->page == 'editBiospecimen') {
             unset($values['bidInfo']);
             $viewURL = "Location: ".$baseURL."/biobanking/viewBiospecimen/?";


### PR DESCRIPTION
bidInfo was added to allow JS validation in the editBiospecimen page. However, it was not unset and therefore there was an attempt to use that array to update the database. bidInfo has now been unset.