### PR TITLE
Limit site access

### DIFF
--- a/php/optionsendpoint.class.inc
+++ b/php/optionsendpoint.class.inc
@@ -115,16 +115,26 @@ class OptionsEndpoint implements RequestHandlerInterface
         $specCont = new SpecimenController($db, $user);
         $shipDAO = new ShipmentDAO($db);
 
+        $userCenters = implode(',',$user->getCenterIDs());
+
         // XXX: This should eventually be replaced by a call directly to a
         // Candidate endpoint or Candidate controller that will be able to
         // provide Candidate Objects.
-        $query      = 'SELECT CandID as id,
-                       PSCID as pscid,
-                       Sex as sex,
-                       GROUP_CONCAT(DiagnosisID) as diagnosisIds
-                       FROM candidate
-                       LEFT JOIN candidate_diagnosis_rel USING (CandID)
-                       GROUP BY CandID';
+        $query      = "SELECT c.CandID as id,
+                            PSCID as pscid,
+                            Sex as sex,
+                            GROUP_CONCAT(DISTINCT DiagnosisID) as diagnosisIds
+                       FROM candidate c
+                            LEFT JOIN session s USING (CandID)
+                            LEFT JOIN biobank_specimen bs ON (s.Id = bs.SessionID)
+                            LEFT JOIN biobank_container bc USING (ContainerID)
+                            LEFT JOIN biobank_specimen_pool_rel bspr USING (SpecimenID)
+                            LEFT JOIN biobank_pool bp USING (PoolID)
+                            LEFT JOIN candidate_diagnosis_rel USING (CandID)
+                       WHERE s.CenterID IN ($userCenters)
+                            OR bc.CenterID IN ($userCenters)
+                            OR bp.CenterID IN ($userCenters)
+                       GROUP BY CandID";
         $candidates = $db->pselectWithIndexKey($query, array(), 'id');
         foreach($candidates as $id => $candidate) {
           $candidate['diagnosisIds'] = $candidate['diagnosisIds'] ? explode(',', $candidate['diagnosisIds']) : [];
@@ -168,13 +178,19 @@ class OptionsEndpoint implements RequestHandlerInterface
         // XXX: This should eventually be replaced by a call directly to a
         // Session Controller or Session Options endpoint that will be able to
         // provide these options.
-        $query  = 'SELECT c.CandID as candidateId,                              
-                         s.ID sessionId,                                        
-                         s.Visit_label as label,                                
-                         s.CenterID as centerId                                 
-                 FROM candidate c                                               
-                 LEFT JOIN session s                                            
-                   USING(CandID)';
+        $query  = "SELECT c.CandID as candidateId,
+                         s.ID sessionId,
+                         s.Visit_label as label,
+                         s.CenterID as centerId
+                 FROM candidate c
+                        LEFT JOIN session s USING(CandID)
+                        LEFT JOIN biobank_specimen bs ON (s.Id = bs.SessionID)
+                        LEFT JOIN biobank_container bc USING (ContainerID)
+                        LEFT JOIN biobank_specimen_pool_rel bspr USING (SpecimenID)
+                        LEFT JOIN biobank_pool bp USING (PoolID)
+                WHERE s.CenterID IN ($userCenters)
+                        OR bc.CenterID IN ($userCenters)
+                        OR bp.CenterID IN ($userCenters)";
         $result = $db->pselect($query, array());
         $candidateSessions = array();
         $sessionCenters    = array();

--- a/php/specimen.class.inc
+++ b/php/specimen.class.inc
@@ -56,6 +56,7 @@ class Specimen implements \JsonSerializable, \LORIS\Data\DataInstance
     private $typeId;
     private $quantity;
     private $unitId;
+    private $containerCenterId;
     private $fTCycle;
     private $parentSpecimenIds;
     private $candidateId;
@@ -401,6 +402,11 @@ class Specimen implements \JsonSerializable, \LORIS\Data\DataInstance
         return $this->analysis;
     }
 
+    public function setContainerCenterId(int $containerCenterId)
+    {
+        $this->containerCenterId = $containerCenterId;
+    }
+
     // FIXME: THIS IS A MASSIVE HACK. Specimens should not be provisioned if
     // their Container is not provisioned. Therefore, a check must be made that
     // the Container's Center ID is accesibile by the current User. This function
@@ -412,11 +418,13 @@ class Specimen implements \JsonSerializable, \LORIS\Data\DataInstance
      */
     public function getCenterId()
     {
-        $db           = \Database::singleton();
-        $containerDAO = new ContainerDAO($db);
-        $containerId  = $this->getContainerId();
-        $container    = $containerDAO->getInstanceFromId($containerId);
-        return $container->getCenterId();
+//        $db           = \Database::singleton();
+//        $containerDAO = new ContainerDAO($db);
+//        $containerId  = $this->getContainerId();
+//        $container    = $containerDAO->getInstanceFromId($containerId);
+//        return $container->getCenterId();
+
+        return $this->containerCenterId;
     }
 
     /**
@@ -433,6 +441,7 @@ class Specimen implements \JsonSerializable, \LORIS\Data\DataInstance
         isset($data['typeId'])            && $this->setTypeId((int) $data['typeId']);
         isset($data['quantity'])          && $this->setQuantity((string) $data['quantity']);
         isset($data['unitId'])            && $this->setUnitId((int) $data['unitId']);
+        isset($data['containerCenterId']) && $this->setContainerCenterId((int) $data['containerCenterId']);
         isset($data['fTCycle'])           && $this->setFTCycle((int) $data['fTCycle']);
         isset($data['parentSpecimenIds']) && $this->setParentSpecimenIds($data['parentSpecimenIds']);
         isset($data['candidateId'])       && $this->setCandidateId((int) $data['candidateId']);
@@ -481,6 +490,7 @@ class Specimen implements \JsonSerializable, \LORIS\Data\DataInstance
                 'typeId'            => $this->typeId,
                 'quantity'          => $this->quantity,
                 'unitId'            => $this->unitId,
+                'containerCenterId' => $this->containerCenterId,
                 'fTCycle'           => $this->fTCycle,
                 'parentSpecimenIds' => $this->parentSpecimenIds,
                 'candidateId'       => $this->candidateId,

--- a/php/specimendao.class.inc
+++ b/php/specimendao.class.inc
@@ -381,6 +381,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
             foreach ($row as $value) {
                 $pA[$row['protocolId']][$row['attributeId']]['label']           = $row['label'];
                 $pA[$row['protocolId']][$row['attributeId']]['datatypeId']      = $row['datatypeId'];
+                $pA[$row['protocolId']][$row['attributeId']]['refTableId']      = $row['refTableId'];
                 $pA[$row['protocolId']][$row['attributeId']]['required']        = (int) $row['required'];
                 $pA[$row['protocolId']][$row['attributeId']]['showInDataTable'] = (int) $row['showInDataTable'];
             }

--- a/php/specimendao.class.inc
+++ b/php/specimendao.class.inc
@@ -381,7 +381,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
             foreach ($row as $value) {
                 $pA[$row['protocolId']][$row['attributeId']]['label']           = $row['label'];
                 $pA[$row['protocolId']][$row['attributeId']]['datatypeId']      = $row['datatypeId'];
-                $pA[$row['protocolId']][$row['attributeId']]['refTableId']      = $row['refTableId'];
+                $pA[$row['protocolId']][$row['attributeId']]['refTableId']      = $row['refTableId'] ?? null;
                 $pA[$row['protocolId']][$row['attributeId']]['required']        = (int) $row['required'];
                 $pA[$row['protocolId']][$row['attributeId']]['showInDataTable'] = (int) $row['showInDataTable'];
             }

--- a/php/specimendao.class.inc
+++ b/php/specimendao.class.inc
@@ -107,24 +107,25 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
         $query = "SELECT bs.SpecimenID,
                       bs.ContainerID,
                       bs.SpecimenTypeID,
-                      bs.Quantity, 
+                      bs.Quantity,
                       bs.UnitID,
+                      bc.CenterID as ContainerCenterID,
                       bsf.FreezeThawCycle,
                       GROUP_CONCAT(bspa.ParentSpecimenID) as ParentSpecimenIDs,
                       s.CandID as CandidateID,
-                      bs.SessionID, 
+                      bs.SessionID,
                       (SELECT FLOOR(DATEDIFF(s.Date_visit, c.DoB)/365.25)) as CandidateAge,
                       bspr.PoolID,
                       bsc.SpecimenProtocolID as CollectionProtocolID,
                       bsc.Quantity as CollectionQuantity,
-                      bsc.UnitID as CollectionUnitID, 
+                      bsc.UnitID as CollectionUnitID,
                       bsc.CenterID as CollectionCenterID,
                       bsc.ExaminerID as CollectionExaminerID,
-                      bsc.Date as CollectionDate, 
+                      bsc.Date as CollectionDate,
                       bsc.Time as CollectionTime,
-                      bsc.Comments as CollectionComments, 
+                      bsc.Comments as CollectionComments,
                       bsc.Data as CollectionData,
-                      bsp.SpecimenProtocolID as PreparationProtocolID, 
+                      bsp.SpecimenProtocolID as PreparationProtocolID,
                       bsp.CenterID as PreparationCenterID,
                       bsp.ExaminerID as PreparationExaminerID,
                       bsp.Date as PreparationDate,
@@ -134,11 +135,12 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
                       bsa.SpecimenProtocolID as AnalysisProtocolID,
                       bsa.CenterID as AnalysisCenterID,
                       bsa.ExaminerID as AnalysisExaminerID,
-                      bsa.Date as AnalysisDate, 
+                      bsa.Date as AnalysisDate,
                       bsa.Time as AnalysisTime,
                       bsa.Comments as AnalysisComments,
                       bsa.Data as AnalysisData
                FROM biobank_specimen bs
+               JOIN biobank_container bc USING (ContainerID)
                LEFT JOIN biobank_specimen_freezethaw bsf
                  USING (SpecimenID)
                LEFT JOIN session s
@@ -202,7 +204,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
                          FreezeThaw as freezeThaw
                   FROM biobank_specimen_type";
         $types = $this->db->pselectWithIndexKey($query, [], 'id');
-        
+
         $query = "SELECT SpecimenTypeID as id,
                          ParentSpecimenTypeID as parentId
                   FROM biobank_specimen_type_parent";
@@ -224,7 +226,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
     public function getProtocols() : array
     {
         $query     = "SELECT SpecimenProtocolID as id,
-                         Label as label, 
+                         Label as label,
                          SpecimenProcessID as processId,
                          SpecimenTypeID as typeId
                   FROM biobank_specimen_protocol";
@@ -276,7 +278,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
     public function getAttributeDatatypes() : array
     {
         $query = 'SELECT DatatypeID as id,
-                         Datatype as datatype 
+                         Datatype as datatype
                   FROM biobank_specimen_attribute_datatype';
         $attributeDatatypes = $this->db->pselectWithIndexKey($query, [], 'id');
 
@@ -295,7 +297,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
     public function getUnits() : array
     {
         $query = "SELECT UnitID as id,
-                         Label as label 
+                         Label as label
                   FROM biobank_unit";
         $units = $this->db->pselectWithIndexKey($query, [], 'id');
 
@@ -330,7 +332,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
     }
 
     /**
-     * Queries all rows of the biobank_specimen_type_container_type_rel table 
+     * Queries all rows of the biobank_specimen_type_container_type_rel table
      * and returns a nested array of container type value, with the specimen
      * Type ID as the index.
      *
@@ -609,7 +611,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
      * @param array $data              Values to be converted to array.
      * @param array $parentSpecimenIds IDs of the parent Specimen.
      *
-     * @return Specimen 
+     * @return Specimen
      */
     private function getInstanceFromSQL(array $data, array $parentSpecimenIds) : Specimen
     {
@@ -619,6 +621,7 @@ class SpecimenDAO extends \LORIS\Data\ProvisionerInstance
         isset($data['SpecimenTypeID'])  && $specimen->setTypeId((int) $data['SpecimenTypeID']);
         isset($data['Quantity'])        && $specimen->setQuantity((string) $data['Quantity']);
         isset($data['UnitID'])          && $specimen->setUnitId((int) $data['UnitID']);
+        isset($data['ContainerCenterID']) && $specimen->setContainerCenterId((int) $data['ContainerCenterID']);
         isset($data['FreezeThawCycle']) && $specimen->setFTCycle((int) $data['FreezeThawCycle']);
         !empty($parentSpecimenIds)      && $specimen->setParentSpecimenIds(!empty($parentSpecimenIds) ? $parentSpecimenIds : null);
         isset($data['CandidateID'])     && $specimen->setCandidateId((int) $data['CandidateID']);


### PR DESCRIPTION
center ID speed + limit the visibility of candidates in "add specimen" tab to all those whom you should have access to
 - candidates with sessions at your sites
 - candidates with samples at your sites
 - candidates with sample pools at your sites