### PR TITLE
feat(specimen): Remove project selection from Add specimen form (Issue #254)

### DIFF
--- a/jsx/biobankIndex.js
+++ b/jsx/biobankIndex.js
@@ -41,7 +41,6 @@ class BiobankIndex extends Component {
         examiners: {},
         users: {},
         projects: {},
-        sessionCenters: {},
         sessions: {},
         specimen: {
           types: {},

--- a/jsx/customFields.js
+++ b/jsx/customFields.js
@@ -18,7 +18,6 @@ function CustomFields(props) {
 
   return attributes.map(
     (attribute, key) => {
-      console.log(attribute.label);
       const datatype = options.specimen.attributeDatatypes[attribute.datatypeId]
         .datatype;
       if (datatype === 'text' || datatype === 'number') {

--- a/jsx/customFields.js
+++ b/jsx/customFields.js
@@ -18,6 +18,7 @@ function CustomFields(props) {
 
   return attributes.map(
     (attribute, key) => {
+      console.log(attribute.label);
       const datatype = options.specimen.attributeDatatypes[attribute.datatypeId]
         .datatype;
       if (datatype === 'text' || datatype === 'number') {

--- a/jsx/globals.js
+++ b/jsx/globals.js
@@ -223,35 +223,19 @@ function Globals(props) {
 
   const projectField = () => specimen && (
     <InlineField
-      loading={props.loading}
       label='Projects'
-      clearAll={props.clearAll}
-      updateValue={()=>props.updateSpecimen(current.specimen)}
-      edit={() => props.edit('project')}
-      editValue={() => props.editSpecimen(specimen)}
       value={specimen.projectIds.length !== 0 ?
         specimen.projectIds
           .map((id) => options.projects[id])
           .join(', ') : 'None'}
-      editable={editable.project}
-    >
-      <SelectElement
-        name='projectIds'
-        options={props.options.projects}
-        onUserInput={props.setSpecimen}
-        multiple={true}
-        emptyOption={false}
-        value={props.current.specimen.projectIds}
-        errorMessage={props.errors.specimen.projectIds}
-      />
-    </InlineField>
+    />
   );
 
   const drawField = specimen && (
     <InlineField
       label='Draw Site'
       value={options.centers[
-        options.sessionCenters[specimen.sessionId]?.centerId
+        options.sessions[specimen.sessionId]?.centerId
       ]}
     />
   );
@@ -500,10 +484,8 @@ Globals.propTypes = {
     }).isRequired,
     projects: PropTypes.arrayOf(PropTypes.string).isRequired,
     centers: PropTypes.arrayOf(PropTypes.string).isRequired,
-    sessionCenters: PropTypes.arrayOf(PropTypes.string),
     candidates: PropTypes.arrayOf(PropTypes.string),
     sessions: PropTypes.arrayOf(PropTypes.string),
-    candidateSessions: PropTypes.arrayOf(PropTypes.string), // Added
     attributes: PropTypes.arrayOf(
       PropTypes.shape({
         label: PropTypes.string.isRequired,

--- a/jsx/poolSpecimenForm.js
+++ b/jsx/poolSpecimenForm.js
@@ -234,7 +234,7 @@ class PoolSpecimenForm extends React.Component {
             disabled={!isEmpty(list) || !filter.candidateId}
             value={filter.sessionId}
             options={mapFormOptions(
-              (options?.candidateSessions?.[filter.candidateId] || {}),
+              (options?.candidates?.[filter.candidateId] || {}),
               'label'
             )}
           />
@@ -348,7 +348,6 @@ PoolSpecimenForm.propTypes = {
     ).isRequired,
   }).isRequired,
   options: PropTypes.shape({
-    candidateSessions: PropTypes.obj,
     specimen: PropTypes.shape({
       units: PropTypes.string,
       types: PropTypes.arrayOf(PropTypes.string),

--- a/jsx/poolTab.js
+++ b/jsx/poolTab.js
@@ -105,7 +105,7 @@ class PoolTab extends Component {
       return <td>{value}</td>;
     case 'Visit Label':
       if (candidatePermission) {
-        const sessId = Object.values(options.candidateSessions[candId]).find(
+        const sessId = Object.values(options.candidates[candId]).find(
           (sess) => sess.label == value
         )?.id;
         const sessionPermission = sessId !== undefined;
@@ -260,7 +260,6 @@ PoolTab.propTypes = {
     }).isRequired,
     centers: PropTypes.arrayOf(PropTypes.string).isRequired,
     candidates: PropTypes.arrayOf(PropTypes.string),
-    candidateSessions: PropTypes.arrayOf(PropTypes.string),
     projects: PropTypes.arrayOf(PropTypes.string).isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,

--- a/jsx/processForm.js
+++ b/jsx/processForm.js
@@ -284,7 +284,6 @@ SpecimenProcessForm.propTypes = {
     }).isRequired,
     centers: PropTypes.arrayOf(PropTypes.string).isRequired,
     candidates: PropTypes.arrayOf(PropTypes.string),
-    candidateSessions: PropTypes.arrayOf(PropTypes.string),
     sessions: PropTypes.arrayOf(PropTypes.string),
     examiners: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,

--- a/jsx/shipmentTab.js
+++ b/jsx/shipmentTab.js
@@ -242,7 +242,6 @@ ShipmentTab.propTypes = {
     candidates: PropTypes.arrayOf(PropTypes.string).isRequired,
     users: PropTypes.object,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    candidateSessions: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 
   // Functional props

--- a/jsx/specimenForm.js
+++ b/jsx/specimenForm.js
@@ -16,7 +16,7 @@ import {
 
 const initialState = {
   list: {},
-  current: {container: {}, projectId: null, sessionId: null, candidateId: null},
+  current: {container: {}, projectIds: [], sessionId: null, candidateId: null},
   printBarcodes: false,
   errors: {specimen: {}, container: {}, list: {}},
 };
@@ -113,7 +113,7 @@ class SpecimenForm extends React.Component {
   setSession(session, sessionId) {
     const {current} = clone(this.state);
     current.centerId = this.props.options.sessions[sessionId].centerId;
-    current.projectId = this.props.options.sessions[sessionId].projectId;
+    current.projectIds = [this.props.options.sessions[sessionId].projectId];
     current.originId = current.centerId;
     current.sessionId = sessionId;
     this.setState({current});
@@ -207,7 +207,7 @@ class SpecimenForm extends React.Component {
     };
 
     const renderGlobalFields = () => {
-      const { sessionId, candidateId, projectId } = current
+      const { sessionId, candidateId, projectIds } = current
       if (parent && candidateId && sessionId) {
         const parentBarcodes = Object.values(parent).map(
           (item) => item.container.barcode
@@ -229,7 +229,7 @@ class SpecimenForm extends React.Component {
             />
             <StaticElement
               label="Project"
-              text={options.projects[projectId]}
+              text={options.projects[projectIds[0]]}
             />
           </>
         );
@@ -271,7 +271,7 @@ class SpecimenForm extends React.Component {
             />
             <StaticElement
               label="Project"
-              text={options.projects[projectId]}
+              text={options.projects[projectIds[0]]}
             />
           </>
         );

--- a/jsx/specimenForm.js
+++ b/jsx/specimenForm.js
@@ -16,7 +16,7 @@ import {
 
 const initialState = {
   list: {},
-  current: {container: {}},
+  current: {container: {}, projectId: null, sessionId: null, candidateId: null},
   printBarcodes: false,
   errors: {specimen: {}, container: {}, list: {}},
 };
@@ -38,7 +38,6 @@ class SpecimenForm extends React.Component {
     this.setList = this.setList.bind(this);
     this.setCurrent = this.setCurrent.bind(this);
     this.setContainer = this.setContainer.bind(this);
-    this.setProject = this.setProject.bind(this);
     this.setSession = this.setSession.bind(this);
     this.generateBarcodes = this.generateBarcodes.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -106,19 +105,6 @@ class SpecimenForm extends React.Component {
   }
 
   /**
-   * Set the current project
-   *
-   * @param {string} name - project name
-   * @param {string} value - project value
-   * @return {Promise}
-   */
-  setProject(name, value) {
-    const {current} = clone(this.state);
-    current[name] = [value];
-    return new Promise((res) => this.setState({current}, res()));
-  }
-
-  /**
    * When a session is selected, set the sessionId, centerId and originId.
    *
    * @param {object} session
@@ -126,35 +112,12 @@ class SpecimenForm extends React.Component {
    */
   setSession(session, sessionId) {
     const {current} = clone(this.state);
-    current.centerId = this.props.options.sessionCenters[sessionId].centerId;
+    current.centerId = this.props.options.sessions[sessionId].centerId;
+    current.projectId = this.props.options.sessions[sessionId].projectId;
     current.originId = current.centerId;
     current.sessionId = sessionId;
     this.setState({current});
   }
-
-  //XXX Deprecated function since the introduction of a barcode endpoint for barcode generation
-  /**
-   * Increment the current barcode
-   *
-   * @param {string} pscid - the PSCID
-   * @param {number} increment - the amount to increment
-   * @return {number}
-   */
-  // incrementBarcode(pscid, increment = 0) {
-  //   increment++;
-  //   const barcode = padBarcode(pscid, increment);
-  //   if (Object.values(this.props.data.containers)
-  //     .some((container) => container.barcode === barcode)
-  //   ) {
-  //     increment = this.incrementBarcode(pscid, increment);
-  //   }
-  //   if (Object.values(this.state.list)
-  //     .some((specimen) => specimen.container.barcode === barcode)
-  //   ) {
-  //     increment = this.incrementBarcode(pscid, increment);
-  //   }
-  //   return increment;
-  // }
 
   /**
    * Fetch Barcodes from the backend.
@@ -244,59 +207,73 @@ class SpecimenForm extends React.Component {
     };
 
     const renderGlobalFields = () => {
-      if (parent && current.candidateId && current.sessionId) {
+      const { sessionId, candidateId, projectId } = current
+      if (parent && candidateId && sessionId) {
         const parentBarcodes = Object.values(parent).map(
           (item) => item.container.barcode
         );
         const parentBarcodesString = parentBarcodes.join(', ');
         return (
-          <div>
+          <>
             <StaticElement
               label="Parent Specimen(s)"
               text={parentBarcodesString}
             />
             <StaticElement
               label="PSCID"
-              text={options.candidates[current.candidateId].pscid}
+              text={options.candidates[candidateId].pscid}
             />
             <StaticElement
               label="Visit Label"
-              text={options.sessions[current.sessionId].label}
+              text={options.sessions[sessionId].label}
             />
-          </div>
+            <StaticElement
+              label="Project"
+              text={options.projects[projectId]}
+            />
+          </>
         );
       } else {
-        const sessions = current.candidateId ?
-          mapFormOptions(
-            options.candidateSessions[current.candidateId], 'label'
-          ) : {};
+        const sessionsObject = current.candidateId
+          ? options.candidates[current.candidateId].sessionIds.reduce((acc, sessionId) => {
+              if (options.sessions[sessionId]) {
+                acc[sessionId] = options.sessions[sessionId];
+              }
+              return acc;
+            }, {})
+          : {};        
+        const mappedSessions = mapFormOptions(sessionsObject, 'label');
         const candidates = mapFormOptions(
           this.props.options.candidates, 'pscid'
         );
         return (
-          <div>
+          <>
             <SearchableDropdown
               name="candidateId"
               label="PSCID"
               options={candidates}
               onUserInput={this.setCurrent}
               required={true}
-              value={current.candidateId}
+              value={candidateId}
               placeHolder='Search for a PSCID'
               errorMessage={errors.specimen.candidateId}
             />
             <SelectElement
               name='sessionId'
               label='Visit Label'
-              options={sessions}
+              options={mappedSessions}
               onUserInput={this.setSession}
               required={true}
-              value={current.sessionId}
-              disabled={current.candidateId ? false : true}
+              value={sessionId}
+              disabled={candidateId ? false : true}
               errorMessage={errors.specimen.sessionId}
               autoSelect={true}
             />
-          </div>
+            <StaticElement
+              label="Project"
+              text={options.projects[projectId]}
+            />
+          </>
         );
       }
     };
@@ -311,7 +288,7 @@ class SpecimenForm extends React.Component {
             'label'
           );
           return (
-            <div>
+            <>
               <TextboxElement
                 name="quantity"
                 label="Remaining Quantity"
@@ -328,7 +305,7 @@ class SpecimenForm extends React.Component {
                 value={this.props.current.specimen.unitId}
                 autoSelect={true}
               />
-            </div>
+            </>
           );
         }
       }
@@ -366,16 +343,6 @@ class SpecimenForm extends React.Component {
           <div className="col-xs-11">
             {renderNote()}
             {renderGlobalFields()}
-            <SelectElement
-              name='projectIds'
-              label='Project'
-              options={this.props.options.projects}
-              onUserInput={this.setProject}
-              required={true}
-              value={current.projectIds}
-              disabled={current.candidateId ? false : true}
-              errorMessage={errors.specimen.projectIds}
-            />
             {renderRemainingQuantityFields()}
           </div>
         </div>
@@ -438,14 +405,8 @@ SpecimenForm.propTypes = {
 
   // Options prop: Configuration options for specimen, containers, etc.
   options: PropTypes.shape({
-    sessionCenters: PropTypes.arrayOf(
-      PropTypes.shape({
-        centerId: PropTypes.number.isRequired,
-      })
-    ).isRequired,
     candidates: PropTypes.arrayOf(PropTypes.string).isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    candidateSessions: PropTypes.arrayOf(PropTypes.string).isRequired,
     projects: PropTypes.arrayOf(PropTypes.string).isRequired,
     specimen: PropTypes.shape({
       typeUnits: PropTypes.string,

--- a/jsx/specimenTab.js
+++ b/jsx/specimenTab.js
@@ -61,7 +61,7 @@ class SpecimenTab extends Component {
     case 'Container Type':
       return options.container.typesPrimary[value].label;
     case 'Diagnosis':
-      if (value) {
+      if (Array.isArray(value) && value.length > 0) {
         return value.map((id) => options.diagnoses[id].label);
       }
       break;
@@ -88,40 +88,40 @@ class SpecimenTab extends Component {
    */
   formatSpecimenColumns(column, value, row) {
     const {data, options} = this.props;
-    value = this.mapSpecimenColumns(column, value);
+    const display = this.mapSpecimenColumns(column, value);
     const candidate = Object.values(options.candidates)
       .find((cand) => cand?.pscid == row['PSCID']);
     const candidatePermission = candidate !== undefined;
     switch (column) {
     case 'Barcode':
-      return <td><Link to={`/barcode=${value}`}>{value}</Link></td>;
+      return <td><Link to={`/barcode=${display}`}>{display}</Link></td>;
     case 'Parent Specimens':
       // TODO: if the user doesn't have access then these shouldn't be hyperlinked
-      const barcodes = value && value.map((id, key) => {
-        return <Link key={key} to={`/barcode=${value}`}>{value}</Link>;
+      const barcodes = display && display.map((id, key) => {
+        return <Link key={key} to={`/barcode=${display}`}>{display}</Link>;
       }).reduce((prev, curr) => [prev, ', ', curr]);
       return <td>{barcodes}</td>;
     case 'PSCID':
       if (candidatePermission) {
         return (
           <td>
-            <a href={loris.BaseURL + '/' + candidate.id}>{value}</a>
+            <a href={loris.BaseURL + '/' + candidate.id}>{display}</a>
           </td>
         );
       }
-      return <td>{value}</td>;
+      return <td>{display}</td>;
     case 'Visit Label':
       if (candidatePermission) {
-        const ses = Object.values(options.candidateSessions[candidate.id])
-          .find((sess) => sess.label == value).id;
+        const sessionId = candidate.sessionIds
+          .find(sessionId => options.sessions[sessionId].label === value);
         const visitLabelURL = loris.BaseURL+'/instrument_list/?candID='+
-          candidate.id+'&sessionID='+ses;
-        return <td><a href={visitLabelURL}>{value}</a></td>;
+          candidate.id+'&sessionID='+sessionId;
+        return <td><a href={visitLabelURL}>{display}</a></td>;
       }
-      return <td>{value}</td>;
+      return <td>{display}</td>;
     case 'Status':
       const style = {};
-      switch (value) {
+      switch (display) {
       case 'Available':
         style.color = 'green';
         break;
@@ -135,20 +135,20 @@ class SpecimenTab extends Component {
         style.color = 'red';
         break;
       }
-      return <td style={style}>{value}</td>;
+      return <td style={style}>{display}</td>;
     case 'Projects':
-      return <td>{value.join(', ')}</td>;
+      return <td>{display.join(', ')}</td>;
     case 'Container Barcode':
       // check if container has be queried
       if (
         Object.values(data.containers)
-          .find((container) => container.barcode == value)
+          .find((container) => container.barcode == display)
       ) {
-        return <td><Link to={`/barcode=${value}`}>{value}</Link></td>;
+        return <td><Link to={`/barcode=${display}`}>{display}</Link></td>;
       }
-      return <td>{value}</td>;
+      return <td>{display}</td>;
     default:
-      return <td>{value}</td>;
+      return <td>{display}</td>;
     }
   }
 
@@ -212,7 +212,7 @@ class SpecimenTab extends Component {
         container.statusId,
         specimen.projectIds,
         specimen.centerId,
-        options.sessionCenters[specimen.sessionId]?.centerId,
+        options.sessions[specimen.sessionId]?.centerId,
         specimen.collection.date,
         specimen.collection.time,
         (specimen.preparation||{}).time,
@@ -456,12 +456,6 @@ SpecimenTab.propTypes = {
     projects: PropTypes.arrayOf(PropTypes.string).isRequired,
     candidates: PropTypes.arrayOf(PropTypes.string).isRequired,
     sessions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    sessionCenters: PropTypes.arrayOf(
-      PropTypes.shape({
-        centerId: PropTypes.number.isRequired,
-      })
-    ),
-    candidateSessions: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 
   // Data prop: Contains containers, specimens, and pools data

--- a/php/optionsendpoint.class.inc
+++ b/php/optionsendpoint.class.inc
@@ -141,7 +141,8 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
         $query      = "SELECT c.CandID as id,
                             PSCID as pscid,
                             Sex as sex,
-                            GROUP_CONCAT(DISTINCT DiagnosisID) as diagnosisIds
+                            GROUP_CONCAT(DISTINCT DiagnosisID) as diagnosisIds,
+                            GROUP_CONCAT(DISTINCT s.ID) as sessionIds
                        FROM candidate c
                             LEFT JOIN session s USING (CandID)
                             LEFT JOIN candidate_diagnosis_rel USING (CandID)
@@ -151,10 +152,12 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
                           CandID";
         $candidates = $db->pselectWithIndexKey($query, [], 'id');
         foreach ($candidates as $id => $candidate) {
-            $candidate['diagnosisIds'] = $candidate['diagnosisIds']
+            $candidates[$id]['diagnosisIds'] = $candidate['diagnosisIds']
                 ? explode(',', $candidate['diagnosisIds'])
                 : [];
-            $candidates[$id]           = $candidate;
+            $candidates[$id]['sessionIds']  = $candidate['sessionIds']
+                ? explode(',', $candidate['sessionIds'])
+                : [];
         }
 
         // XXX: This should eventually be replaced by a call directly to a
@@ -163,11 +166,15 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
         $query     = 'SELECT DiagnosisID as id, Name as label FROM diagnosis';
         $diagnoses = $db->pselectWithIndexKey($query, [], 'id');
 
-        // XXX: This should eventually be replaced by a call directly to a
-        // Session endpoint or Session controller that will be able to provide
-        // Session Objects.
-        $query    = 'SELECT ID as id, Visit_label as label FROM session';
-        $sessions = $db->pselectWithIndexKey($query, [], 'id');
+        $sessionQuery = "SELECT
+            s.ID as id,
+            s.Visit_label as label,
+            s.CenterID as centerId,
+            s.ProjectID as projectId
+        FROM session s
+        WHERE s.CenterID IN ($userCenters)
+          AND s.ProjectID IN ($userProjects)";
+        $sessions = $db->pselectWithIndexKey($sessionQuery, [], 'id');
 
         // XXX: This should eventually be replaced by a call directly to a
         // Examiner endpoint or Examiner controller that will be able to provide
@@ -191,38 +198,6 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
         //     }
         // }
 
-        // XXX: This should eventually be replaced by a call directly to a
-        // Session Controller or Session Options endpoint that will be able to
-        // provide these options.
-        $query  = "SELECT
-                      c.CandID as candidateId,
-                      s.ID sessionId,
-                      s.Visit_label as label,
-                      s.CenterID as centerId
-                  FROM
-                      candidate c
-                  LEFT JOIN session s USING (CandID)
-                  LEFT JOIN biobank_specimen bs ON (s.Id = bs.SessionID)
-                  LEFT JOIN biobank_container bc USING (ContainerID)
-                  WHERE
-                      s.CenterID IN ($userCenters)
-                      AND s.ProjectID IN ($userProjects)";
-        $result = $db->pselect($query, []);
-        $candidateSessions = [];
-        $sessionCenters    = [];
-        foreach ($result as $row) {
-            $candidate = $row['candidateId'];
-            $session   = $row['sessionId'];
-            if (!isset($candidateSessions[$candidate][$session])) {
-                $candidateSessions[$candidate][$session] = [];
-            };
-            $ses          =& $candidateSessions[$candidate][$session];
-            $ses['id']    = $session;
-            $ses['label'] = $row['label'];
-
-            $sessionCenters[$session]['centerId'] = $row['centerId'];
-        }
-
         $shipment = [
             'statuses' => $shipDAO->getStatuses(),
             'types'    => $shipDAO->getTypes(),
@@ -236,8 +211,6 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
             'centers'           => $centers,
             'examiners'         => $examiners,
             'users'             => $users,
-            'candidateSessions' => $candidateSessions,
-            'sessionCenters'    => $sessionCenters,
             'container'         => $contCont->getOptions(),
             'specimen'          => $specCont->getOptions(),
             'shipment'          => $shipment,


### PR DESCRIPTION
This PR resolves #254 by removing the "Project" selection field from the "Add specimen" form.

Motivation:
The project to which a specimen belongs can be reliably derived from the associated session. Requiring users to explicitly select the project during specimen creation introduces redundancy and potential for errors.

Detailed Explanation:
- Removed the "Project" dropdown or selection component from the "Add specimen" form in the user interface.

- No database schema changes were required.

How to Test:
1. Navigate to the "Add specimen" page.
2. Verify that the "Project" selection field is no longer present.
3. Create a new specimen, ensuring you select a valid session.
4. After the specimen is created, view its details. Confirm that the specimen is correctly associated with the project of the selected session.
5. Try creating specimens with different sessions belonging to different projects to ensure the project association is always derived correctly.

Considerations:
- This change simplifies the user experience and reduces the number of manual steps required for specimen creation.

Future Changes Needed:
- Currently the database hold project information for the specimen in a many to many rel table. A future PR should remove this from the schema and use the project derived through the session for all specimens.

No breaking changes introduced.