### PR TITLE
fix(endpoint): Cast response body to string before generating ETag

### DIFF
--- a/php/endpoint.class.inc
+++ b/php/endpoint.class.inc
@@ -170,6 +170,6 @@ abstract class Endpoint
      */
     public function ETag(ServerRequestInterface $request) : string
     {
-        return md5(json_encode($this->_handleGET($request)->getBody()));
+        return md5(json_encode((string) $this->_handleGET($request)->getBody()));
     }
 }


### PR DESCRIPTION
This PR addresses a type-related issue in Endpoint::ETag() where the response body was being passed directly to json_encode() without ensuring it was a string.

The previous implementation:
`md5(json_encode($this->_handleGET($request)->getBody()))`

could result in incorrect or inconsistent ETag values because getBody() returns a stream object, not a raw string.

The updated implementation:
`md5(json_encode((string) $this->_handleGET($request)->getBody()))`
ensures the stream is properly converted to a string before encoding, providing reliable and predictable ETag values.

