### PR TITLE
Refactor Specimen Pooling and Filtering to use Visit Labels

### DIFF
--- a/jsx/poolSpecimenForm.js
+++ b/jsx/poolSpecimenForm.js
@@ -65,10 +65,6 @@ class PoolSpecimenForm extends React.Component {
   setFilter(name, value) {
     const {filter} = clone(this.state);
 
-    if (name == 'candidateId') {
-      filter.sessionId = null;
-    }
-
     filter[name] = value;
     this.setState({filter});
   }
@@ -80,6 +76,7 @@ class PoolSpecimenForm extends React.Component {
    */
   setPoolList(containerId) {
     let {filter, list, pool, count} = clone(this.state);
+    const { options } = this.props;
 
     // Increase count
     count++;
@@ -91,7 +88,7 @@ class PoolSpecimenForm extends React.Component {
     // Set current global values
     if (isEmpty(list)) {
       filter.candidateId = specimen.candidateId;
-      filter.sessionId = specimen.sessionId;
+      filter.visitLabel = options.sesssions[specimen.sessionId]?.label;
       filter.typeId = specimen.typeId;
       filter.centerId = container.centerId;
     }
@@ -141,13 +138,14 @@ class PoolSpecimenForm extends React.Component {
    */
   validateListItem(containerId) {
     const {list, filter} = clone(this.state);
+    const { options } = this.props;
     const container = this.props.data.containers[containerId];
     const specimen = this.props.data.specimens[container.specimenId];
 
     // Throw error if new list item does not meet requirements.
     if (!isEmpty(list)
       && (specimen.candidateId != filter.candidateId
-      || specimen.sessionId != filter.sessionId
+      || options.sessions[specimen.sessionId]?.label != filter.visitLabel
       || specimen.typeId != filter.typeId
       || container.centerId !== filter.centerId)
     ) {
@@ -228,15 +226,12 @@ class PoolSpecimenForm extends React.Component {
             options={mapFormOptions(options.candidates, 'pscid')}
           />
           <SearchableDropdown
-            name='sessionId'
+            name='visitLabel'
             label='Visit Label'
             onUserInput={this.setFilter}
-            disabled={!isEmpty(list) || !filter.candidateId}
-            value={filter.sessionId}
-            options={mapFormOptions(
-              (options?.candidates?.[filter.candidateId] || {}),
-              'label'
-            )}
+            disabled={!isEmpty(list)}
+            value={filter.visitLabel}
+            options={options.visitLabels}
           />
           <div className='row'>
             <div className='col-xs-6'>
@@ -386,8 +381,8 @@ class BarcodeInput extends PureComponent {
 
             const candidateMatch = !filter.candidateId
               || specimen.candidateId == filter.candidateId;
-            const sessionMatch = !filter.sessionId
-              || specimen.sessionId == filter.sessionId;
+            const sessionMatch = !filter.visitLabel
+              || options.sessions[specimen.sessionId]?.label == filter.visitLabel;
             const typeMatch = !filter.typeId
               || specimen.typeId == filter.typeId;
 
@@ -440,7 +435,7 @@ BarcodeInput.propTypes = {
   }).isRequired,
   filter: PropTypes.shape({
     candidateId: PropTypes.string,
-    sessionId: PropTypes.string,
+    visitLabel: PropTypes.string,
     typeId: PropTypes.string,
   }).isRequired,
   options: PropTypes.shape({

--- a/jsx/poolSpecimenForm.js
+++ b/jsx/poolSpecimenForm.js
@@ -88,7 +88,7 @@ class PoolSpecimenForm extends React.Component {
     // Set current global values
     if (isEmpty(list)) {
       filter.candidateId = specimen.candidateId;
-      filter.visitLabel = options.sesssions[specimen.sessionId]?.label;
+      filter.visitLabel = options.sessions[specimen.sessionId]?.label;
       filter.typeId = specimen.typeId;
       filter.centerId = container.centerId;
     }

--- a/jsx/specimenTab.js
+++ b/jsx/specimenTab.js
@@ -207,7 +207,7 @@ class SpecimenTab extends Component {
         candidate?.sex || null,
         specimen.candidateAge,
         candidate?.diagnosisIds || null,
-        options.sessions[specimen.sessionId].label,
+        options.sessions[specimen.sessionId]?.label,
         specimen.poolId ? (data.pools[specimen.poolId]||{}).label : null,
         container.statusId,
         specimen.projectId,
@@ -280,8 +280,9 @@ class SpecimenTab extends Component {
         options: diagnoses,
       }},
       {label: 'Visit Label', show: true, filter: {
-        name: 'session',
-        type: 'text',
+        name: 'visitLabel',
+        type: 'select',
+        options: options.visitLabels,
       }},
       {label: 'Pool', show: false, filter: {
         name: 'pool',

--- a/php/optionsendpoint.class.inc
+++ b/php/optionsendpoint.class.inc
@@ -197,6 +197,15 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
         //         unset($centers[$id]);
         //     }
         // }
+        //
+        $query = "
+            SELECT
+                DISTINCT s.Visit_label as label
+            FROM biobank_specimen bs
+            JOIN session s ON (bs.sessionID = s.ID)
+        ";
+        $results = $db->pselectcol($query, []);
+        $visitlabels = array_combine($results, $results);
 
         $shipment = [
             'statuses' => $shipDAO->getStatuses(),
@@ -207,6 +216,7 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
             'candidates'        => $candidates,
             'diagnoses'         => $diagnoses,
             'sessions'          => $sessions,
+            'visitLabels'       => $visitlabels,
             'projects'          => \Utility::getProjectList(),
             'centers'           => $centers,
             'examiners'         => $examiners,


### PR DESCRIPTION
### Summary
This PR refactors the specimen filtering and pooling logic to prioritize **Visit Labels** over specific **Session IDs**. This change allows users to filter and pool specimens across different candidates based on common visit milestones (e.g., "Baseline", "Follow-up") rather than being restricted to unique session records.

### Changes

#### PHP (Backend)
- **OptionsEndpoint.class.inc**: Added a new query to fetch `DISTINCT s.Visit_label` from the `biobank_specimen` and `session` tables. This data is now passed to the frontend as a `visitLabels` option, providing a standardized list for dropdowns.

#### React/JSX (Frontend)
- **PoolSpecimenForm.js**:
    - Replaced `sessionId` with `visitLabel` in the component state and filter logic.
    - Updated `validateListItem` to ensure specimens added to a pool share the same Visit Label.
    - Updated the "Visit Label" input from a candidate-specific session list to a global `SearchableDropdown` using the new `visitLabels` options.
    - Adjusted `BarcodeInput` logic to match scanned specimens against the selected `visitLabel`.
- **SpecimenTab.js**:
    - Changed the "Visit Label" table filter from a `text` input to a `select` dropdown for better data consistency.
    - Added defensive optional chaining (`?.`) when accessing session labels to prevent runtime errors on missing data.

#### Impact
- **Consistency**: Users now select from a predefined list of visit labels rather than typing them manually or selecting session IDs.
- **Pooling Flexibility**: Facilitates the creation of specimen pools based on visit types across the entire biobank.

Resolves #281
