### PR TITLE
[Biobank] Add Lab Technician flag to filter examiner dropdown

### DIFF
--- a/jsx/processForm.js
+++ b/jsx/processForm.js
@@ -133,12 +133,17 @@ const SpecimenProcessForm = (props) => {
     />
   );
 
-  const labTechExaminers = mapFormOptions(
-    options.examiners.filter(e =>
-      e.labTechnician === '1' || e.id === process.examinerId
-    ),
-    'label'
+  const filteredExaminers = Object.keys(options.examiners).reduce(
+    (result, id) => {
+      const examiner = options.examiners[id];
+      if (examiner.labTechnician === '1' || id == process.examinerId) {
+        result[id] = examiner;
+      }
+      return result;
+    },
+    {}
   );
+  const labTechExaminers = mapFormOptions(filteredExaminers, 'label');
 
   if (typeId && edit === true) {
     const elements = [
@@ -152,6 +157,7 @@ const SpecimenProcessForm = (props) => {
         value={process.examinerId}
         errorMessage={errors.examinerId}
         autoSelect={true}
+        sortByValue={true}
       />,
       <DateElement
         name="date"

--- a/jsx/processForm.js
+++ b/jsx/processForm.js
@@ -8,7 +8,7 @@ import {
   TimeElement,
   TextareaElement,
   StaticElement,
-} from '../../../jsx/Form'; // Temporary CBIGR Override for 26.0 
+} from '../../../jsx/Form'; // Temporary CBIGR Override for 26.0
 import {mapFormOptions, clone} from './helpers.js';
 import CustomFields from './customFields';
 
@@ -134,9 +134,12 @@ const SpecimenProcessForm = (props) => {
   );
 
   const labTechExaminers = mapFormOptions(
-    options.examiners.filter(e => e.labTechnician === '1'),
+    options.examiners.filter(e =>
+      e.labTechnician === '1' || e.id === process.examinerId
+    ),
     'label'
   );
+
   if (typeId && edit === true) {
     const elements = [
       protocolField,
@@ -187,7 +190,7 @@ const SpecimenProcessForm = (props) => {
     const protocolAttributes = options.specimen.protocolAttributes[
       process.protocolId
     ] || [];
-    
+
     const protocolStaticFields = protocolAttributes.map((attribute) => {
       let value = process.data?.[attribute.id]; // Fetch the corresponding value from process.data
 

--- a/jsx/processForm.js
+++ b/jsx/processForm.js
@@ -133,14 +133,17 @@ const SpecimenProcessForm = (props) => {
     />
   );
 
-  const examiners = mapFormOptions(options.examiners, 'label');
+  const labTechExaminers = mapFormOptions(
+    options.examiners.filter(e => e.labTechnician === '1'),
+    'label'
+  );
   if (typeId && edit === true) {
     const elements = [
       protocolField,
       <SelectElement
         name="examinerId"
         label="Done By"
-        options={examiners}
+        options={labTechExaminers}
         onUserInput={setProcess}
         required={true}
         value={process.examinerId}

--- a/php/optionsendpoint.class.inc
+++ b/php/optionsendpoint.class.inc
@@ -179,7 +179,8 @@ class OptionsEndpoint extends \NDB_Page implements RequestHandlerInterface
         // XXX: This should eventually be replaced by a call directly to a
         // Examiner endpoint or Examiner controller that will be able to provide
         // Examiner Objects.
-        $query     = 'SELECT examinerID as id, full_name as label FROM examiners';
+        $query     = 'SELECT examinerID as id, full_name as label, '
+                     . 'LabTechnician as labTechnician FROM examiners';        
         $examiners = $db->pselectWithIndexKey($query, [], 'id');
 
         // XXX: This should eventually be replaced by a call directly to a

--- a/sql/patches/2026-04-16_add-lab-technician-to-examiner.sql
+++ b/sql/patches/2026-04-16_add-lab-technician-to-examiner.sql
@@ -1,1 +1,1 @@
-ALTER TABLE examiner ADD COLUMN `LabTechnician` tinyint(1) DEFAULT 0 AFTER `radiologist`;
+ALTER TABLE examiners ADD COLUMN `LabTechnician` tinyint(1) DEFAULT 0 AFTER `radiologist`;

--- a/sql/patches/2026-04-16_add-lab-technician-to-examiner.sql
+++ b/sql/patches/2026-04-16_add-lab-technician-to-examiner.sql
@@ -1,1 +1,0 @@
-ALTER TABLE examiners ADD COLUMN `LabTechnician` tinyint(1) DEFAULT 0 AFTER `radiologist`;

--- a/sql/patches/2026-04-16_add-lab-technician-to-examiner.sql
+++ b/sql/patches/2026-04-16_add-lab-technician-to-examiner.sql
@@ -1,0 +1,1 @@
+ALTER TABLE examiner ADD COLUMN `LabTechnician` tinyint(1) DEFAULT 0 AFTER `radiologist`;


### PR DESCRIPTION
### Description
Adds a `LabTechnician` flag to the `examiner` table to allow filtering the "Done By" dropdown in biobank specimen processing to show only lab technicians, rather than the full examiner list which has become unwieldy.

**Changes:**
- Added `LabTechnician` column to `examiner` table (tinyint, default 0)
- Updated biobank options endpoint to include the lab technician flag in examiner query
- Modified specimen process form to filter dropdown to show only lab technicians when in edit mode
- Historical records continue to display correctly using full examiner list

### Testing Instructions
1. Apply the SQL patch
2. Manually set `LabTechnician = 1` for known lab technicians in the examiner table
3. Navigate to biobank specimen processing
4. Create/edit a specimen process - verify "Done By" dropdown shows only lab technicians
5. View existing processed specimens - verify examiner names display correctly even for non-lab-tech examiners

### Related Issues
- Fixes aces/CBIGR#776
- Addresses https://github.com/aces/biobank/issues/251 cleanup request from September 2023 to reduce examiner list bloat in biobank module

### Caveat for Existing Projects
After applying this patch, existing projects must manually set the `LabTechnician` flag to 1 for appropriate examiners, otherwise the "Done By" dropdown will be empty.

linked to aces/CBGIR#786